### PR TITLE
BTC swap: amount must be higher than fee

### DIFF
--- a/components/transfer.tsx
+++ b/components/transfer.tsx
@@ -152,7 +152,7 @@ const Transfer = () => {
           symbol: "ZETA",
           formatted,
         })
-      } else if (sendType === "crossChainSwap") {
+      } else if (["crossChainSwap", "crossChainSwapBTC"].includes(sendType)) {
         const fee =
           fees?.["feesZEVM"][destinationTokenSelected?.chain_name]?.totalFee
         const amount = parseFloat(fee)


### PR DESCRIPTION
* fix BTC swap: amount must be higher than fee. The amount is of course fine, it's just the fee wasn't calculated correctly.

<img width="466" alt="Screenshot 2024-01-02 at 18 13 37" src="https://github.com/zeta-chain/example-frontend/assets/332151/59058701-d319-403c-8cf8-f000355f42c2">
